### PR TITLE
Simplify JSON creation for OpenAI

### DIFF
--- a/fx/fxOpenAI.m
+++ b/fx/fxOpenAI.m
@@ -11,51 +11,48 @@
 
 let
     // Determine the model to use, defaulting to "gpt-4o-mini" if none is provided
-    _model = if model = null then "gpt-4o-mini" else model,
+    _model = model ?? "gpt-4o-mini",
 
     // Include the system message if provided, otherwise leave it blank
-    _system = if system = null then "" else "{
-        ""role"": ""system"",
-        ""content"": """ & system & """
-      },",
+    _system = system ?? [
+        role    = "system",
+        content = system
+    ],
 
     // Define the OpenAI API key (replace <OPENAI_API_KEY> with your actual key)
     _api_key = "<OPENAI_API_KEY>",
 
     // Define the base URL and relative path for the API endpoint
-    _url_base = "https://api.openai.com/",
+    _url_base = "https://api.openai.com",
     _url_rel = "v1/chat/completions",
 
     // Create the JSON body for the API request, including the user message and optional system message
-    ContentJSON = "{
-    ""model"": """ & _model & """,
-    ""messages"": [
-      " & _system & "
-      {
-        ""role"": ""user"",
-        ""content"": """ & user & """
-      }
-    ]
-  }",
-
-    // Convert the JSON string to binary format to send in the Web request
-    ContentBinary = Text.ToBinary(ContentJSON),
+    requestData = [
+        model = _model,
+        messages = {
+            _system,
+            [
+                role = "user",
+                content = user
+            ]
+        }
+    ],
 
     // Make the API call using Web.Contents and capture the response
     Source = Json.Document(
         Web.Contents(
-            _url_base, 
+            _url_base,
             [
                 RelativePath = _url_rel,
                 Headers = [
-                    #"Content-Type" = "application/json", 
+                    #"Content-Type" = "application/json",
                     #"Authorization" = "Bearer " & _api_key
                 ],
-                Content = ContentBinary
+                Content = Json.FromValue( requestData )
             ]
         )
     ),
-  
+
     // Extract the first choice from the API response
     choice = Source[choices]{0},
 
@@ -66,7 +63,7 @@ let
     reason = Table.SelectRows(Record.ToTable(choice), each [Name] = "finish_reason")[Value]{0},
 
     // Return both the content and the finish reason as the result
-    Result = {content, reason} 
+    Result = {content, reason}
 
 in
     Result


### PR DESCRIPTION
This makes it so you don't have to manually hard-code json into your queries. 

If you  ever have to `Text.Format` is really nice for formatting strings using a template, and arguments. You can use records, or lists.